### PR TITLE
fix: incorrect module naming

### DIFF
--- a/lib/AdsConsent.js
+++ b/lib/AdsConsent.js
@@ -28,7 +28,7 @@ import { NativeModules } from 'react-native';
 import AdsConsentDebugGeography from './AdsConsentDebugGeography';
 import AdsConsentStatus from './AdsConsentStatus';
 
-const native = NativeModules.GoogleAdsConsentModule;
+const native = NativeModules.RNGoogleAdsConsentModule;
 
 export default {
   /**

--- a/lib/internal/GoogleAdsNativeEventEmitter.js
+++ b/lib/internal/GoogleAdsNativeEventEmitter.js
@@ -17,20 +17,20 @@
 
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
-const { GoogleAdsModule } = NativeModules;
+const { RNGoogleAdsModule } = NativeModules;
 
 class GoogleAdsNativeEventEmitter extends NativeEventEmitter {
   constructor() {
-    super(GoogleAdsModule);
+    super(RNGoogleAdsModule);
     this.ready = false;
   }
 
   addListener(eventType, listener, context) {
     if (!this.ready) {
-      GoogleAdsModule.eventsNotifyReady(true);
+      RNGoogleAdsModule.eventsNotifyReady(true);
       this.ready = true;
     }
-    GoogleAdsModule.eventsAddListener(eventType);
+    RNGoogleAdsModule.eventsAddListener(eventType);
 
     let subscription = super.addListener(`google_ads_${eventType}`, listener, context);
 
@@ -45,7 +45,7 @@ class GoogleAdsNativeEventEmitter extends NativeEventEmitter {
     // we will modify it to do our native unsubscription then call the original
     let originalRemove = subscription.remove;
     let newRemove = () => {
-      GoogleAdsModule.eventsRemoveListener(eventType, false);
+      RNGoogleAdsModule.eventsRemoveListener(eventType, false);
       if (super.removeSubscription != null) {
         // This is for RN <= 0.64 - 65 and greater no longer have removeSubscription
         super.removeSubscription(subscription);
@@ -59,13 +59,13 @@ class GoogleAdsNativeEventEmitter extends NativeEventEmitter {
   }
 
   removeAllListeners(eventType) {
-    GoogleAdsModule.eventsRemoveListener(eventType, true);
+    RNGoogleAdsModule.eventsRemoveListener(eventType, true);
     super.removeAllListeners(`google_ads_${eventType}`);
   }
 
   // This is likely no longer ever called, but it is here for backwards compatibility with RN <= 0.64
   removeSubscription(subscription) {
-    GoogleAdsModule.eventsRemoveListener(subscription.eventType.replace('google_ads_'), false);
+    RNGoogleAdsModule.eventsRemoveListener(subscription.eventType.replace('google_ads_'), false);
     if (super.removeSubscription) {
       super.removeSubscription(subscription);
     }


### PR DESCRIPTION
### Description

This fixes #9 and makes the package usable again. With this changes I was able to render a banner ad again.