### PR TITLE
fix: displaying banner ads, wrong config in docs

### DIFF
--- a/docs/european-user-consent.mdx
+++ b/docs/european-user-consent.mdx
@@ -30,14 +30,14 @@ The following steps show the various methods and ways of handling consent within
 By default, the Google Mobile Ads SDK initializes app measurement and begins sending user-level event data to Google immediately when the app starts.
 If your app will be used by users within the EEA, it is important you prevent app measurement until your first ad has been requested (after consent).
 
-Within your projects `app.json` file, set the `admob_delay_app_measurement_init` to `true` to delay app measurement:
+Within your projects `app.json` file, set the `delay_app_measurement_init` to `true` to delay app measurement:
 
 ```json
 {
-  "react-native": {
-    "admob_android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
-    "admob_ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
-    "admob_delay_app_measurement_init": true
+  "react-native-google-ads": {
+    "android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "delay_app_measurement_init": true
   }
 }
 ```
@@ -245,7 +245,7 @@ non-personalized ad.
 
 This is a common error which occurs on both Android & iOS when making a request to display a Google-rendered consent form. Unfortunately the reasoning for this error is generic, making it hard to debug. There are a number of steps to check which are usually the cause for this error:
 
-- The AdMob App ID is incorrect: Ensure you have entered the correct ID into the `app.json` file under the `admob_android_app_id` or `admob_ios_app_id` key in the `react-native` config.
+- The AdMob App ID is incorrect: Ensure you have entered the correct ID into the `app.json` file under the `android_app_id` or `ios_app_id` key in the `react-native-google-ads` config.
 - A publisher ID is incorrect: Ensure your entered publisher IDs are correct.
   - The publisher ID needs to be available on the same account as your AdMob App ID.
 - The user is outside of the EEA: If a user does not need to provide consent, the form request will error. Ensure you have checked the users status via `requestInfoUpdate`. If using an emulator, ensure you set a debug location via `setDebugGeography`.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -49,14 +49,14 @@ Under the "App settings" menu item, you can find the "App ID":
 ![Google AdMob App ID](https://prismic-io.s3.amazonaws.com/invertase%2F52dd6900-108c-47a6-accb-699fde963b99_new+project+%2813%29.jpg)
 
 Within the root of your React Native project, open the `app.json` file and add the
-`admob_android_app_id` & `admob_ios_app_id` keys with the IDs from the Google AdMob console:
+`android_app_id` & `ios_app_id` keys with the IDs from the Google AdMob console:
 
 ```json
 // <project-root>/app.json
 {
-  "react-native": {
-    "admob_android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
-    "admob_ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx"
+  "react-native-google-ads": {
+    "android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx"
   }
 }
 ```

--- a/lib/ads/BannerAd.js
+++ b/lib/ads/BannerAd.js
@@ -97,7 +97,7 @@ function BannerAd({ unitId, size, requestOptions, ...props }) {
   );
 }
 
-const GoogleAdsBannerView = requireNativeComponent('GoogleAdsBannerView', BannerAd);
+const GoogleAdsBannerView = requireNativeComponent('RNGoogleAdsBannerView', BannerAd);
 
 BannerAd.propTypes = {
   unitId: PropTypes.string.isRequired,


### PR DESCRIPTION
### Description

I just initialized a new RN project, followed the docs and noticed the app would crash at first.
The crash was because the google ads sdk couldn't find the app_id from the app.json config.
Therefore I updated the docs.

Then I noticed banners would still not render, one more name change was required (which I think I forgot to push in my previous PR's).