### PR TITLE
fix: incorrect rn config path

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "/jest.config.js",
     "/jest.setup.ts",
     "/ios_config.sh",
-    "/react-native-config.js"
+    "/react-native.config.js"
   ],
   "sdkVersions": {
     "ios": {


### PR DESCRIPTION
### Description

Currently the google-ads config in app.json is ignored because the path to react-native.config.js is incorrect.
