### PR TITLE
fix: rewarded ads crash & request configuration

### DIFF
--- a/__tests__/googleAds.test.ts
+++ b/__tests__/googleAds.test.ts
@@ -4,7 +4,7 @@ describe('Admob', function () {
   describe('setRequestConfiguration()', function () {
     it('throws if config is not an object', function () {
       // @ts-ignore
-      expect(() => admob.setRequestConfiguration('123')).toThrowError(
+      expect(() => admob().setRequestConfiguration('123')).toThrowError(
         "setRequestConfiguration(*) 'requestConfiguration' expected an object value",
       );
     });
@@ -12,7 +12,7 @@ describe('Admob', function () {
     describe('maxAdContentRating', function () {
       it('throws if maxAdContentRating is invalid', function () {
         expect(() =>
-          admob.setRequestConfiguration({
+          admob().setRequestConfiguration({
             maxAdContentRating:
               'Y' as GoogleAdsTypes.MaxAdContentRating[keyof GoogleAdsTypes.MaxAdContentRating],
           }),
@@ -25,7 +25,7 @@ describe('Admob', function () {
     describe('tagForChildDirectedTreatment', function () {
       it('throws if tagForChildDirectedTreatment not a boolean', function () {
         expect(() =>
-          admob.setRequestConfiguration({
+          admob().setRequestConfiguration({
             // @ts-ignore
             tagForChildDirectedTreatment: 'true',
           }),
@@ -38,12 +38,25 @@ describe('Admob', function () {
     describe('tagForUnderAgeOfConsent', function () {
       it('throws if tagForUnderAgeOfConsent not a boolean', function () {
         expect(() =>
-          admob.setRequestConfiguration({
+          admob().setRequestConfiguration({
             // @ts-ignore
             tagForUnderAgeOfConsent: 'false',
           }),
         ).toThrowError(
           "setRequestConfiguration(*) 'requestConfiguration.tagForUnderAgeOfConsent' expected a boolean value",
+        );
+      });
+    });
+
+    describe('testDeviceIdentifiers', function () {
+      it('throws if testDeviceIdentifiers not an array', function () {
+        expect(() =>
+          admob().setRequestConfiguration({
+            // @ts-ignore
+            testDeviceIdentifiers: 'EMULATOR',
+          }),
+        ).toThrowError(
+          "setRequestConfiguration(*) 'requestConfiguration.testDeviceIdentifiers' expected an array value",
         );
       });
     });

--- a/e2e/interstitial.e2e.js
+++ b/e2e/interstitial.e2e.js
@@ -37,7 +37,6 @@ describe('googleAds InterstitialAd', function () {
           foo: 'bar',
         },
         keywords: ['foo', 'bar'],
-        testDevices: ['abc', 'EMULATOR'],
         contentUrl: 'https://invertase.io',
         location: [0, 0],
         locationAccuracy: 10,

--- a/e2e/rewarded.e2e.js
+++ b/e2e/rewarded.e2e.js
@@ -83,7 +83,6 @@ describe('googleAds RewardedAd', function () {
           foo: 'bar',
         },
         keywords: ['foo', 'bar'],
-        testDevices: ['abc', 'EMULATOR'],
         contentUrl: 'https://invertase.io',
         location: [0, 0],
         locationAccuracy: 10,

--- a/ios/RNGoogleAds/RNGoogleAdsModule.m
+++ b/ios/RNGoogleAds/RNGoogleAdsModule.m
@@ -61,12 +61,12 @@ RCT_EXPORT_METHOD(setRequestConfiguration
   }
 
   if (requestConfiguration[@"tagForChildDirectedTreatment"]) {
-    BOOL tag = (BOOL)requestConfiguration[@"tagForChildDirectedTreatment"];
+    BOOL tag = [requestConfiguration[@"tagForChildDirectedTreatment"] boolValue];
     [GADMobileAds.sharedInstance.requestConfiguration tagForChildDirectedTreatment:tag];
   }
 
   if (requestConfiguration[@"tagForUnderAgeOfConsent"]) {
-    BOOL tag = (BOOL)requestConfiguration[@"tagForUnderAgeOfConsent"];
+    BOOL tag = [requestConfiguration[@"tagForUnderAgeOfConsent"] boolValue];
     [GADMobileAds.sharedInstance.requestConfiguration tagForUnderAgeOfConsent:tag];
   }
 

--- a/ios/RNGoogleAds/RNGoogleAdsRewardedModule.m
+++ b/ios/RNGoogleAds/RNGoogleAdsRewardedModule.m
@@ -116,10 +116,13 @@ RCT_EXPORT_METHOD(rewardedLoad
         rewardedMap[requestId] = rewardedAd;
         rewardedDelegateMap[requestId] = fullScreenContentDelegate;
         GADAdReward *reward = rewardedAd.adReward;
-        NSDictionary *data = @{
-          @"type" : reward.type,
-          @"amount" : reward.amount,
-        };
+        NSMutableDictionary *data = [NSMutableDictionary dictionary];
+        if (reward.type != nil) {
+          [data setValue:reward.type forKey:@"type"];
+        }
+        if (reward.amount != nil) {
+          [data setValue:reward.amount forKey:@"amount"];
+        }
         [RNGoogleAdsCommon sendAdEvent:GOOGLE_ADS_EVENT_REWARDED
                              requestId:requestId
                                   type:GOOGLE_ADS_EVENT_REWARDED_LOADED
@@ -142,10 +145,13 @@ RCT_EXPORT_METHOD(rewardedShow
         presentFromRootViewController:RCTSharedApplication().delegate.window.rootViewController
              userDidEarnRewardHandler:^{
                GADAdReward *reward = rewardedAd.adReward;
-               NSDictionary *data = @{
-                 @"type" : reward.type,
-                 @"amount" : reward.amount,
-               };
+               NSMutableDictionary *data = [NSMutableDictionary dictionary];
+               if (reward.type != nil) {
+                 [data setValue:reward.type forKey:@"type"];
+               }
+               if (reward.amount != nil) {
+                 [data setValue:reward.amount forKey:@"amount"];
+               }
                [RNGoogleAdsCommon sendAdEvent:GOOGLE_ADS_EVENT_REWARDED
                                     requestId:requestId
                                          type:GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD

--- a/lib/ads/InterstitialAd.js
+++ b/lib/ads/InterstitialAd.js
@@ -37,7 +37,7 @@ export default class InterstitialAd extends MobileAd {
     }
 
     const requestId = _interstitialRequest++;
-    return new InterstitialAd('interstitial', googleAds, requestId, adUnitId, options);
+    return new InterstitialAd('interstitial', googleAds(), requestId, adUnitId, options);
   }
 
   load() {

--- a/lib/ads/RewardedAd.js
+++ b/lib/ads/RewardedAd.js
@@ -37,7 +37,7 @@ export default class RewardedAd extends MobileAd {
     }
 
     const requestId = _rewardedRequest++;
-    return new RewardedAd('rewarded', googleAds, requestId, adUnitId, options);
+    return new RewardedAd('rewarded', googleAds(), requestId, adUnitId, options);
   }
 
   load() {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1178,6 +1178,6 @@ export const InterstitialAd: typeof GoogleAdsTypes.InterstitialAd;
 export const RewardedAd: typeof GoogleAdsTypes.RewardedAd;
 export const BannerAd: React.SFC<GoogleAdsTypes.BannerAd>;
 
-declare const defaultExport: GoogleAdsTypes.Module & GoogleAdsTypes.Statics;
+declare const defaultExport: () => GoogleAdsTypes.Module & GoogleAdsTypes.Statics;
 
 export default defaultExport;

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,13 +75,17 @@ class GoogleAdsModule extends Module {
 // import { SDK_VERSION } from '@invertase/react-native-google-ads';
 export const SDK_VERSION = version;
 
-export default new GoogleAdsModule('AppName', {
+const googleMobileAds = new GoogleAdsModule('AppName', {
   statics,
   version,
   namespace,
   nativeModuleName,
   nativeEvents: ['google_ads_interstitial_event', 'google_ads_rewarded_event'],
 });
+
+export default () => {
+  return googleMobileAds;
+};
 
 export { default as AdsConsentDebugGeography } from './AdsConsentDebugGeography';
 export { default as AdsConsentStatus } from './AdsConsentStatus';

--- a/lib/validateAdRequestConfiguration.js
+++ b/lib/validateAdRequestConfiguration.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { hasOwnProperty, isBoolean, isObject } from '../lib/common';
+import { hasOwnProperty, isArray, isBoolean, isObject } from '../lib/common';
 import MaxAdContentRating from './MaxAdContentRating';
 
 export default function validateAdRequestConfiguration(requestConfiguration) {
@@ -56,6 +56,14 @@ export default function validateAdRequestConfiguration(requestConfiguration) {
     }
 
     out.tagForUnderAgeOfConsent = requestConfiguration.tagForUnderAgeOfConsent;
+  }
+
+  if (hasOwnProperty(requestConfiguration, 'testDeviceIdentifiers')) {
+    if (!isArray(requestConfiguration.testDeviceIdentifiers)) {
+      throw new Error("'requestConfiguration.testDeviceIdentifiers' expected an array value");
+    }
+
+    out.testDeviceIdentifiers = requestConfiguration.testDeviceIdentifiers;
   }
 
   return out;


### PR DESCRIPTION
### Description

Fixes #3, Fixes #5

Also makes sure that the default export aligns with the docs and previous rnfb implementation. (Calling admob().setConfiguration() instead of admob.setConfiguration())