### PR TITLE
feat(android, sdks)!: update to the latest gms:play-services-ads:20.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.google.android.gms:play-services-ads:19.8.0") { force = true; }
+  implementation("com.google.android.gms:play-services-ads:20.5.0") { force = true; }
   implementation "com.google.android.ads.consent:consent-library:${ReactNative.ext.getVersion("ads", "consent")}"
 }
 

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
@@ -17,6 +17,7 @@ package io.invertase.googleads;
  *
  */
 
+import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
@@ -28,15 +29,13 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.gms.ads.AdListener;
-import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.LoadAdError;
 import java.util.Map;
 import javax.annotation.Nonnull;
-import androidx.annotation.NonNull;
 import org.jetbrains.annotations.NotNull;
-
 
 public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<ReactViewGroup> {
   private static final String REACT_CLASS = "RNGoogleAdsBannerView";
@@ -100,7 +99,7 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
   public void setSize(ReactViewGroup reactViewGroup, String value) {
     size = ReactNativeGoogleAdsCommon.getAdSize(value, reactViewGroup);
 
-   WritableMap payload = Arguments.createMap();
+    WritableMap payload = Arguments.createMap();
 
     int width = size.getWidth();
     int height = size.getHeight();

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
@@ -28,11 +28,15 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
+import org.jetbrains.annotations.NotNull;
+
 
 public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<ReactViewGroup> {
   private static final String REACT_CLASS = "RNGoogleAdsBannerView";
@@ -40,7 +44,6 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
   private String EVENT_AD_FAILED_TO_LOAD = "onAdFailedToLoad";
   private String EVENT_AD_OPENED = "onAdOpened";
   private String EVENT_AD_CLOSED = "onAdClosed";
-  private String EVENT_AD_LEFT_APPLICATION = "onAdLeftApplication";
 
   private Boolean requested = false;
   private AdRequest request;
@@ -97,17 +100,10 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
   public void setSize(ReactViewGroup reactViewGroup, String value) {
     size = ReactNativeGoogleAdsCommon.getAdSize(value, reactViewGroup);
 
-    int width;
-    int height;
-    WritableMap payload = Arguments.createMap();
+   WritableMap payload = Arguments.createMap();
 
-    if (size == AdSize.SMART_BANNER) {
-      width = (int) PixelUtil.toDIPFromPixel(size.getWidthInPixels(reactViewGroup.getContext()));
-      height = (int) PixelUtil.toDIPFromPixel(size.getHeightInPixels(reactViewGroup.getContext()));
-    } else {
-      width = size.getWidth();
-      height = size.getHeight();
-    }
+    int width = size.getWidth();
+    int height = size.getHeight();
 
     payload.putDouble("width", width);
     payload.putDouble("height", height);
@@ -160,7 +156,8 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
           }
 
           @Override
-          public void onAdFailedToLoad(int errorCode) {
+          public void onAdFailedToLoad(@NonNull @NotNull LoadAdError loadAdError) {
+            int errorCode = loadAdError.getCode();
             WritableMap payload = ReactNativeGoogleAdsCommon.errorCodeToMap(errorCode);
             sendEvent(reactViewGroup, EVENT_AD_FAILED_TO_LOAD, payload);
           }
@@ -173,11 +170,6 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
           @Override
           public void onAdClosed() {
             sendEvent(reactViewGroup, EVENT_AD_CLOSED, null);
-          }
-
-          @Override
-          public void onAdLeftApplication() {
-            sendEvent(reactViewGroup, EVENT_AD_LEFT_APPLICATION, null);
           }
         });
   }

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
@@ -35,7 +35,6 @@ import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.LoadAdError;
 import java.util.Map;
 import javax.annotation.Nonnull;
-import org.jetbrains.annotations.NotNull;
 
 public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<ReactViewGroup> {
   private static final String REACT_CLASS = "RNGoogleAdsBannerView";
@@ -155,7 +154,7 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
           }
 
           @Override
-          public void onAdFailedToLoad(@NonNull @NotNull LoadAdError loadAdError) {
+          public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
             int errorCode = loadAdError.getCode();
             WritableMap payload = ReactNativeGoogleAdsCommon.errorCodeToMap(errorCode);
             sendEvent(reactViewGroup, EVENT_AD_FAILED_TO_LOAD, payload);

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
@@ -22,8 +22,6 @@ import android.location.Location;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.Display;
-import android.util.Log;
-import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -33,17 +31,8 @@ import com.facebook.react.views.view.ReactViewGroup;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
-import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.FullScreenContentCallback;
-import com.google.android.gms.ads.LoadAdError;
-import com.google.android.gms.ads.MobileAds;
-import com.google.android.gms.ads.RequestConfiguration;
-import com.google.android.gms.ads.interstitial.InterstitialAd;
-import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
-import org.jetbrains.annotations.NotNull;
 
 import io.invertase.googleads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
@@ -107,8 +96,6 @@ public class ReactNativeGoogleAdsCommon {
         return AdSize.FULL_BANNER;
       case "LEADERBOARD":
         return AdSize.LEADERBOARD;
-      case "SMART_BANNER":
-        return AdSize.SMART_BANNER;
       default:
       case "BANNER":
         return AdSize.BANNER;

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
@@ -17,7 +17,6 @@ package io.invertase.googleads;
  *
  */
 
-
 import android.location.Location;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -33,14 +32,13 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
-
 import io.invertase.googleads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public class ReactNativeGoogleAdsCommon {
@@ -179,7 +177,8 @@ public class ReactNativeGoogleAdsCommon {
           testDeviceIds.add(id);
         }
       }
-      RequestConfiguration configuration = new RequestConfiguration.Builder().setTestDeviceIds(testDeviceIds).build();
+      RequestConfiguration configuration =
+          new RequestConfiguration.Builder().setTestDeviceIds(testDeviceIds).build();
       MobileAds.setRequestConfiguration(configuration);
     }
 

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
@@ -17,10 +17,13 @@ package io.invertase.googleads;
  *
  */
 
+
 import android.location.Location;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.util.Log;
+import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -30,12 +33,25 @@ import com.facebook.react.views.view.ReactViewGroup;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.RequestConfiguration;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.FullScreenContentCallback;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.RequestConfiguration;
+import com.google.android.gms.ads.interstitial.InterstitialAd;
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
+import org.jetbrains.annotations.NotNull;
+
 import io.invertase.googleads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class ReactNativeGoogleAdsCommon {
@@ -165,15 +181,19 @@ public class ReactNativeGoogleAdsCommon {
       ArrayList<Object> devices =
           Objects.requireNonNull(adRequestOptions.getArray("testDevices")).toArrayList();
 
+      List<String> testDeviceIds = new ArrayList<>();
+
       for (Object device : devices) {
         String id = (String) device;
 
         if (id.equals("EMULATOR")) {
-          builder.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
+          testDeviceIds.add(AdRequest.DEVICE_ID_EMULATOR);
         } else {
-          builder.addTestDevice(id);
+          testDeviceIds.add(id);
         }
       }
+      RequestConfiguration configuration = new RequestConfiguration.Builder().setTestDeviceIds(testDeviceIds).build();
+      MobileAds.setRequestConfiguration(configuration);
     }
 
     if (adRequestOptions.hasKey("contentUrl")) {

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsCommon.java
@@ -30,11 +30,8 @@ import com.facebook.react.views.view.ReactViewGroup;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
-import com.google.android.gms.ads.MobileAds;
-import com.google.android.gms.ads.RequestConfiguration;
 import io.invertase.googleads.common.ReactNativeEventEmitter;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -160,26 +157,6 @@ public class ReactNativeGoogleAdsCommon {
       for (Object keyword : keywords) {
         builder.addKeyword((String) keyword);
       }
-    }
-
-    if (adRequestOptions.hasKey("testDevices")) {
-      ArrayList<Object> devices =
-          Objects.requireNonNull(adRequestOptions.getArray("testDevices")).toArrayList();
-
-      List<String> testDeviceIds = new ArrayList<>();
-
-      for (Object device : devices) {
-        String id = (String) device;
-
-        if (id.equals("EMULATOR")) {
-          testDeviceIds.add(AdRequest.DEVICE_ID_EMULATOR);
-        } else {
-          testDeviceIds.add(id);
-        }
-      }
-      RequestConfiguration configuration =
-          new RequestConfiguration.Builder().setTestDeviceIds(testDeviceIds).build();
-      MobileAds.setRequestConfiguration(configuration);
     }
 
     if (adRequestOptions.hasKey("contentUrl")) {

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsEvent.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsEvent.java
@@ -29,7 +29,6 @@ public class ReactNativeGoogleAdsEvent implements NativeEvent {
   public static final String GOOGLE_ADS_EVENT_ERROR = "error";
   public static final String GOOGLE_ADS_EVENT_OPENED = "opened";
   public static final String GOOGLE_ADS_EVENT_CLICKED = "clicked";
-  public static final String GOOGLE_ADS_EVENT_LEFT_APPLICATION = "left_application";
   public static final String GOOGLE_ADS_EVENT_CLOSED = "closed";
 
   public static final String GOOGLE_ADS_EVENT_REWARDED_LOADED = "rewarded_loaded";

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
@@ -42,7 +42,6 @@ import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 import io.invertase.googleads.common.ReactNativeModule;
 import javax.annotation.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleAdsInterstitialModule";
@@ -77,7 +76,7 @@ public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
               new InterstitialAdLoadCallback() {
 
                 @Override
-                public void onAdLoaded(@NonNull @NotNull InterstitialAd interstitialAd) {
+                public void onAdLoaded(@NonNull InterstitialAd interstitialAd) {
 
                   interstitialAd.setFullScreenContentCallback(
                       new FullScreenContentCallback() {
@@ -104,7 +103,7 @@ public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
                 }
 
                 @Override
-                public void onAdFailedToLoad(@NonNull @NotNull LoadAdError loadAdError) {
+                public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
                   WritableMap error = Arguments.createMap();
                   int errorCode = loadAdError.getCode();
                   String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
@@ -19,34 +19,30 @@ package io.invertase.googleads;
 
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.getCodeAndMessageFromAdErrorCode;
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.sendAdEvent;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_INTERSTITIAL;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLICKED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_ERROR;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_INTERSTITIAL;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_LOADED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLICKED;
 
 import android.app.Activity;
 import android.util.SparseArray;
 import androidx.annotation.NonNull;
-import org.jetbrains.annotations.NotNull;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.FullScreenContentCallback;
-import com.google.android.gms.ads.LoadAdError;
-import com.google.android.gms.ads.MobileAds;
-import com.google.android.gms.ads.RequestConfiguration;
-import com.google.android.gms.ads.interstitial.InterstitialAd;
-import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.FullScreenContentCallback;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.interstitial.InterstitialAd;
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 import io.invertase.googleads.common.ReactNativeModule;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleAdsInterstitialModule";
@@ -56,14 +52,9 @@ public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
     super(reactContext, SERVICE);
   }
 
-  private void sendInterstitialEvent(String type, int requestId, String adUnitId, @Nullable WritableMap error) {
-    sendAdEvent(
-      GOOGLE_ADS_EVENT_INTERSTITIAL,
-      requestId,
-      type,
-      adUnitId,
-      error
-    );
+  private void sendInterstitialEvent(
+      String type, int requestId, String adUnitId, @Nullable WritableMap error) {
+    sendAdEvent(GOOGLE_ADS_EVENT_INTERSTITIAL, requestId, type, adUnitId, error);
   }
 
   @ReactMethod
@@ -72,84 +63,97 @@ public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
     if (currentActivity == null) {
       WritableMap error = Arguments.createMap();
       error.putString("code", "null-activity");
-      error.putString("message", "Interstitial ad attempted to load but the current Activity was null.");
+      error.putString(
+          "message", "Interstitial ad attempted to load but the current Activity was null.");
       sendInterstitialEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error);
       return;
     }
-    currentActivity.runOnUiThread(() -> {
-      AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
-      AdRequest adRequest = adRequestBuilder.build();
+    currentActivity.runOnUiThread(
+        () -> {
+          AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
+          AdRequest adRequest = adRequestBuilder.build();
 
-      InterstitialAdLoadCallback interstitialAdLoadCallback = new InterstitialAdLoadCallback() {
+          InterstitialAdLoadCallback interstitialAdLoadCallback =
+              new InterstitialAdLoadCallback() {
 
-        @Override
-        public void onAdLoaded(@NonNull @NotNull InterstitialAd interstitialAd) {
+                @Override
+                public void onAdLoaded(@NonNull @NotNull InterstitialAd interstitialAd) {
 
-          interstitialAd.setFullScreenContentCallback(
-            new FullScreenContentCallback() {
-              @Override
-              public void onAdDismissedFullScreenContent() {
-                sendInterstitialEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null);
-                interstitialAdArray.put(requestId, null);
-              }
+                  interstitialAd.setFullScreenContentCallback(
+                      new FullScreenContentCallback() {
+                        @Override
+                        public void onAdDismissedFullScreenContent() {
+                          sendInterstitialEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null);
+                          interstitialAdArray.put(requestId, null);
+                        }
 
-              @Override
-              public void onAdClicked() {
-                sendInterstitialEvent(GOOGLE_ADS_EVENT_CLICKED, requestId, adUnitId, null);
-              }
+                        @Override
+                        public void onAdClicked() {
+                          sendInterstitialEvent(
+                              GOOGLE_ADS_EVENT_CLICKED, requestId, adUnitId, null);
+                        }
 
-              @Override
-              public void onAdShowedFullScreenContent() {
-                sendInterstitialEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null);
-              }
-            });
+                        @Override
+                        public void onAdShowedFullScreenContent() {
+                          sendInterstitialEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null);
+                        }
+                      });
 
-          interstitialAdArray.put(requestId, interstitialAd);
-          sendInterstitialEvent(GOOGLE_ADS_EVENT_LOADED, requestId, adUnitId, null);
-        }
+                  interstitialAdArray.put(requestId, interstitialAd);
+                  sendInterstitialEvent(GOOGLE_ADS_EVENT_LOADED, requestId, adUnitId, null);
+                }
 
-        @Override
-        public void onAdFailedToLoad(@NonNull @NotNull LoadAdError loadAdError) {
-          WritableMap error = Arguments.createMap();
-          int errorCode = loadAdError.getCode();
-          String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
-          error.putString("code", codeAndMessage[0]);
-          error.putString("message", codeAndMessage[1]);
-          sendInterstitialEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error);
-        }
-      };
+                @Override
+                public void onAdFailedToLoad(@NonNull @NotNull LoadAdError loadAdError) {
+                  WritableMap error = Arguments.createMap();
+                  int errorCode = loadAdError.getCode();
+                  String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
+                  error.putString("code", codeAndMessage[0]);
+                  error.putString("message", codeAndMessage[1]);
+                  sendInterstitialEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error);
+                }
+              };
 
-      InterstitialAd.load(currentActivity, adUnitId, adRequest, interstitialAdLoadCallback);
-    });
+          InterstitialAd.load(currentActivity, adUnitId, adRequest, interstitialAdLoadCallback);
+        });
   }
 
   @ReactMethod
   public void interstitialShow(int requestId, ReadableMap showOptions, Promise promise) {
     if (getCurrentActivity() == null) {
-      rejectPromiseWithCodeAndMessage(promise, "null-activity", "Interstitial ad attempted to show but the current Activity was null.");
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "null-activity",
+          "Interstitial ad attempted to show but the current Activity was null.");
       return;
     }
-    getCurrentActivity().runOnUiThread(() -> {
-      InterstitialAd interstitialAd = interstitialAdArray.get(requestId);
-      if (interstitialAd == null) {
-        rejectPromiseWithCodeAndMessage(promise, "null-interstitialAd", "Interstitial ad attempted to show but its object was null.");
-        return;
-      }
+    getCurrentActivity()
+        .runOnUiThread(
+            () -> {
+              InterstitialAd interstitialAd = interstitialAdArray.get(requestId);
+              if (interstitialAd == null) {
+                rejectPromiseWithCodeAndMessage(
+                    promise,
+                    "null-interstitialAd",
+                    "Interstitial ad attempted to show but its object was null.");
+                return;
+              }
 
-      if (showOptions.hasKey("immersiveModeEnabled")) {
-        interstitialAd.setImmersiveMode(showOptions.getBoolean("immersiveModeEnabled"));
-      } else {
-        interstitialAd.setImmersiveMode(false);
-      }
+              if (showOptions.hasKey("immersiveModeEnabled")) {
+                interstitialAd.setImmersiveMode(showOptions.getBoolean("immersiveModeEnabled"));
+              } else {
+                interstitialAd.setImmersiveMode(false);
+              }
 
-      String a = String.valueOf(requestId);
+              String a = String.valueOf(requestId);
 
-      if (interstitialAd != null) {
-        interstitialAd.show(getCurrentActivity());
-        promise.resolve(null);
-      } else {
-        rejectPromiseWithCodeAndMessage(promise, "not-ready", "Interstitial ad attempted to show but was not ready.");
-      }
-    });
+              if (interstitialAd != null) {
+                interstitialAd.show(getCurrentActivity());
+                promise.resolve(null);
+              } else {
+                rejectPromiseWithCodeAndMessage(
+                    promise, "not-ready", "Interstitial ad attempted to show but was not ready.");
+              }
+            });
   }
 }

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsInterstitialModule.java
@@ -23,6 +23,8 @@ import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_ERROR;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_LOADED;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLICKED;
 
 import android.app.Activity;
 import android.util.SparseArray;
@@ -87,17 +89,18 @@ public class ReactNativeGoogleAdsInterstitialModule extends ReactNativeModule {
             new FullScreenContentCallback() {
               @Override
               public void onAdDismissedFullScreenContent() {
-                // Called when fullscreen content is dismissed.
-                // Make sure to set your reference to null so you don't
-                // show it a second time.
                 sendInterstitialEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null);
                 interstitialAdArray.put(requestId, null);
               }
 
+              @Override
+              public void onAdClicked() {
+                sendInterstitialEvent(GOOGLE_ADS_EVENT_CLICKED, requestId, adUnitId, null);
+              }
 
               @Override
               public void onAdShowedFullScreenContent() {
-                // Called when fullscreen content is shown.
+                sendInterstitialEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null);
               }
             });
 

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
@@ -21,9 +21,13 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import io.invertase.googleads.common.ReactNativeModule;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class ReactNativeGoogleAdsModule extends ReactNativeModule {
@@ -35,6 +39,24 @@ public class ReactNativeGoogleAdsModule extends ReactNativeModule {
 
   private RequestConfiguration buildRequestConfiguration(ReadableMap requestConfiguration) {
     RequestConfiguration.Builder builder = new RequestConfiguration.Builder();
+
+    if (requestConfiguration.hasKey("testDeviceIdentifiers")) {
+      ArrayList<Object> devices =
+        Objects.requireNonNull(requestConfiguration.getArray("testDeviceIdentifiers")).toArrayList();
+
+      List<String> testDeviceIds = new ArrayList<>();
+
+      for (Object device : devices) {
+        String id = (String) device;
+
+        if (id.equals("EMULATOR")) {
+          testDeviceIds.add(AdRequest.DEVICE_ID_EMULATOR);
+        } else {
+          testDeviceIds.add(id);
+        }
+      }
+      builder.setTestDeviceIds(testDeviceIds);
+    }
 
     if (requestConfiguration.hasKey("maxAdContentRating")) {
       String rating = requestConfiguration.getString("maxAdContentRating");

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
@@ -25,7 +25,6 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import io.invertase.googleads.common.ReactNativeModule;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +41,8 @@ public class ReactNativeGoogleAdsModule extends ReactNativeModule {
 
     if (requestConfiguration.hasKey("testDeviceIdentifiers")) {
       ArrayList<Object> devices =
-        Objects.requireNonNull(requestConfiguration.getArray("testDeviceIdentifiers")).toArrayList();
+          Objects.requireNonNull(requestConfiguration.getArray("testDeviceIdentifiers"))
+              .toArrayList();
 
       List<String> testDeviceIds = new ArrayList<>();
 

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
@@ -2,11 +2,11 @@ package io.invertase.googleads;
 
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.getCodeAndMessageFromAdErrorCode;
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.sendAdEvent;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_ERROR;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_LOADED;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
 
 import android.app.Activity;
 import android.util.SparseArray;
@@ -20,12 +20,12 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
+import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
 import com.google.android.gms.ads.rewarded.RewardItem;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
-import com.google.android.gms.ads.LoadAdError;
 import io.invertase.googleads.common.ReactNativeModule;
 
 public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
@@ -66,66 +66,71 @@ public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
         () -> {
           AdRequest adRequest = new AdRequest.Builder().build();
 
-          RewardedAdLoadCallback rewardedAdLoadCallback = new RewardedAdLoadCallback() {
-            @Override
-            public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
-              WritableMap error = Arguments.createMap();
-              int errorCode = loadAdError.getCode();
-              String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
-              error.putString("code", codeAndMessage[0]);
-              error.putString("message", codeAndMessage[1]);
-              sendRewardedEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error, null);
-            }
-
-            @Override
-            public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
-              RewardItem rewardItem = rewardedAd.getRewardItem();
-              WritableMap data = Arguments.createMap();
-              data.putString("type", rewardItem.getType());
-              data.putInt("amount", rewardItem.getAmount());
-
-              if (adRequestOptions.hasKey("serverSideVerificationOptions")) {
-                ReadableMap serverSideVerificationOptions =
-                  adRequestOptions.getMap("serverSideVerificationOptions");
-
-                if (serverSideVerificationOptions != null) {
-                  ServerSideVerificationOptions.Builder options =
-                    new ServerSideVerificationOptions.Builder();
-
-                  if (serverSideVerificationOptions.hasKey("userId")) {
-                    options.setUserId(serverSideVerificationOptions.getString("userId"));
-                  }
-
-                  if (serverSideVerificationOptions.hasKey("customData")) {
-                    options.setCustomData(serverSideVerificationOptions.getString("customData"));
-                  }
-
-                  rewardedAd.setServerSideVerificationOptions(options.build());
-                }
-              }
-
-              FullScreenContentCallback fullScreenContentCallback = new FullScreenContentCallback() {
+          RewardedAdLoadCallback rewardedAdLoadCallback =
+              new RewardedAdLoadCallback() {
                 @Override
-                public void onAdShowedFullScreenContent() {
-                  sendRewardedEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null, null);
+                public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+                  WritableMap error = Arguments.createMap();
+                  int errorCode = loadAdError.getCode();
+                  String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
+                  error.putString("code", codeAndMessage[0]);
+                  error.putString("message", codeAndMessage[1]);
+                  sendRewardedEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error, null);
                 }
 
                 @Override
-                public void onAdDismissedFullScreenContent() {
-                  sendRewardedEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
+                public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
+                  RewardItem rewardItem = rewardedAd.getRewardItem();
+                  WritableMap data = Arguments.createMap();
+                  data.putString("type", rewardItem.getType());
+                  data.putInt("amount", rewardItem.getAmount());
+
+                  if (adRequestOptions.hasKey("serverSideVerificationOptions")) {
+                    ReadableMap serverSideVerificationOptions =
+                        adRequestOptions.getMap("serverSideVerificationOptions");
+
+                    if (serverSideVerificationOptions != null) {
+                      ServerSideVerificationOptions.Builder options =
+                          new ServerSideVerificationOptions.Builder();
+
+                      if (serverSideVerificationOptions.hasKey("userId")) {
+                        options.setUserId(serverSideVerificationOptions.getString("userId"));
+                      }
+
+                      if (serverSideVerificationOptions.hasKey("customData")) {
+                        options.setCustomData(
+                            serverSideVerificationOptions.getString("customData"));
+                      }
+
+                      rewardedAd.setServerSideVerificationOptions(options.build());
+                    }
+                  }
+
+                  FullScreenContentCallback fullScreenContentCallback =
+                      new FullScreenContentCallback() {
+                        @Override
+                        public void onAdShowedFullScreenContent() {
+                          sendRewardedEvent(
+                              GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null, null);
+                        }
+
+                        @Override
+                        public void onAdDismissedFullScreenContent() {
+                          sendRewardedEvent(
+                              GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
+                        }
+                      };
+
+                  rewardedAd.setFullScreenContentCallback(fullScreenContentCallback);
+
+                  rewardedAdArray.put(requestId, rewardedAd);
+                  sendRewardedEvent(
+                      GOOGLE_ADS_EVENT_REWARDED_LOADED, requestId, adUnitId, null, data);
                 }
               };
 
-              rewardedAd.setFullScreenContentCallback(fullScreenContentCallback);
-
-              rewardedAdArray.put(requestId, rewardedAd);
-              sendRewardedEvent(
-                GOOGLE_ADS_EVENT_REWARDED_LOADED, requestId, adUnitId, null, data);
-            }
-          };
-
           RewardedAd.load(activity, adUnitId, adRequest, rewardedAdLoadCallback);
-    });
+        });
   }
 
   @ReactMethod
@@ -149,16 +154,17 @@ public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
               }
               rewardedAd.setImmersiveMode(immersiveModeEnabled);
 
-              OnUserEarnedRewardListener onUserEarnedRewardListener = new OnUserEarnedRewardListener() {
-                @Override
-                public void onUserEarnedReward(@NonNull RewardItem rewardItem) {
-                  WritableMap data = Arguments.createMap();
-                  data.putString("type", rewardItem.getType());
-                  data.putInt("amount", rewardItem.getAmount());
-                  sendRewardedEvent(
-                    GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD, requestId, adUnitId, null, data);
-                }
-              };
+              OnUserEarnedRewardListener onUserEarnedRewardListener =
+                  new OnUserEarnedRewardListener() {
+                    @Override
+                    public void onUserEarnedReward(@NonNull RewardItem rewardItem) {
+                      WritableMap data = Arguments.createMap();
+                      data.putString("type", rewardItem.getType());
+                      data.putInt("amount", rewardItem.getAmount());
+                      sendRewardedEvent(
+                          GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD, requestId, adUnitId, null, data);
+                    }
+                  };
 
               rewardedAd.show(getCurrentActivity(), onUserEarnedRewardListener);
               promise.resolve(null);

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
@@ -1,11 +1,8 @@
 package io.invertase.googleads;
 
-import static io.invertase.googleads.ReactNativeGoogleAdsCommon.buildAdRequest;
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.getCodeAndMessageFromAdErrorCode;
 import static io.invertase.googleads.ReactNativeGoogleAdsCommon.sendAdEvent;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_ERROR;
-import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_LOADED;
 
@@ -19,11 +16,13 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.OnUserEarnedRewardListener;
 import com.google.android.gms.ads.rewarded.RewardItem;
 import com.google.android.gms.ads.rewarded.RewardedAd;
-import com.google.android.gms.ads.rewarded.RewardedAdCallback;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
+import com.google.android.gms.ads.LoadAdError;
 import io.invertase.googleads.common.ReactNativeModule;
 
 public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
@@ -62,53 +61,54 @@ public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
     }
     activity.runOnUiThread(
         () -> {
-          RewardedAd rewardedAd = new RewardedAd(activity, adUnitId);
+          AdRequest adRequest = new AdRequest.Builder().build();
 
-          RewardedAdLoadCallback adLoadCallback =
-              new RewardedAdLoadCallback() {
-                @Override
-                public void onRewardedAdLoaded() {
-                  RewardItem rewardItem = rewardedAd.getRewardItem();
-                  WritableMap data = Arguments.createMap();
-                  data.putString("type", rewardItem.getType());
-                  data.putInt("amount", rewardItem.getAmount());
-                  sendRewardedEvent(
-                      GOOGLE_ADS_EVENT_REWARDED_LOADED, requestId, adUnitId, null, data);
-                }
-
-                @Override
-                public void onRewardedAdFailedToLoad(int errorCode) {
-                  WritableMap error = Arguments.createMap();
-                  String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
-                  error.putString("code", codeAndMessage[0]);
-                  error.putString("message", codeAndMessage[1]);
-                  sendRewardedEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error, null);
-                }
-              };
-
-          if (adRequestOptions.hasKey("serverSideVerificationOptions")) {
-            ReadableMap serverSideVerificationOptions =
-                adRequestOptions.getMap("serverSideVerificationOptions");
-
-            if (serverSideVerificationOptions != null) {
-              ServerSideVerificationOptions.Builder options =
-                  new ServerSideVerificationOptions.Builder();
-
-              if (serverSideVerificationOptions.hasKey("userId")) {
-                options.setUserId(serverSideVerificationOptions.getString("userId"));
-              }
-
-              if (serverSideVerificationOptions.hasKey("customData")) {
-                options.setCustomData(serverSideVerificationOptions.getString("customData"));
-              }
-
-              rewardedAd.setServerSideVerificationOptions(options.build());
+          RewardedAdLoadCallback rewardedAdLoadCallback = new RewardedAdLoadCallback() {
+            @Override
+            public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+              WritableMap error = Arguments.createMap();
+              int errorCode = loadAdError.getCode();
+              String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
+              error.putString("code", codeAndMessage[0]);
+              error.putString("message", codeAndMessage[1]);
+              sendRewardedEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error, null);
             }
-          }
 
-          rewardedAd.loadAd(buildAdRequest(adRequestOptions), adLoadCallback);
-          rewardedAdArray.put(requestId, rewardedAd);
-        });
+            @Override
+            public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
+              RewardItem rewardItem = rewardedAd.getRewardItem();
+              WritableMap data = Arguments.createMap();
+              data.putString("type", rewardItem.getType());
+              data.putInt("amount", rewardItem.getAmount());
+
+              if (adRequestOptions.hasKey("serverSideVerificationOptions")) {
+                ReadableMap serverSideVerificationOptions =
+                  adRequestOptions.getMap("serverSideVerificationOptions");
+
+                if (serverSideVerificationOptions != null) {
+                  ServerSideVerificationOptions.Builder options =
+                    new ServerSideVerificationOptions.Builder();
+
+                  if (serverSideVerificationOptions.hasKey("userId")) {
+                    options.setUserId(serverSideVerificationOptions.getString("userId"));
+                  }
+
+                  if (serverSideVerificationOptions.hasKey("customData")) {
+                    options.setCustomData(serverSideVerificationOptions.getString("customData"));
+                  }
+
+                  rewardedAd.setServerSideVerificationOptions(options.build());
+                }
+              }
+
+              rewardedAdArray.put(requestId, rewardedAd);
+              sendRewardedEvent(
+                GOOGLE_ADS_EVENT_REWARDED_LOADED, requestId, adUnitId, null, data);
+            }
+          };
+
+          RewardedAd.load(activity, adUnitId, adRequest, rewardedAdLoadCallback);
+    });
   }
 
   @ReactMethod
@@ -130,39 +130,20 @@ public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
               if (showOptions.hasKey("immersiveModeEnabled")) {
                 immersiveModeEnabled = showOptions.getBoolean("immersiveModeEnabled");
               }
+              rewardedAd.setImmersiveMode(immersiveModeEnabled);
 
-              RewardedAdCallback adCallback =
-                  new RewardedAdCallback() {
-                    @Override
-                    public void onRewardedAdOpened() {
-                      sendRewardedEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null, null);
-                    }
+              OnUserEarnedRewardListener onUserEarnedRewardListener = new OnUserEarnedRewardListener() {
+                @Override
+                public void onUserEarnedReward(@NonNull RewardItem rewardItem) {
+                  WritableMap data = Arguments.createMap();
+                  data.putString("type", rewardItem.getType());
+                  data.putInt("amount", rewardItem.getAmount());
+                  sendRewardedEvent(
+                    GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD, requestId, adUnitId, null, data);
+                }
+              };
 
-                    @Override
-                    public void onRewardedAdClosed() {
-                      sendRewardedEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
-                    }
-
-                    @Override
-                    public void onUserEarnedReward(@NonNull RewardItem reward) {
-                      WritableMap data = Arguments.createMap();
-                      data.putString("type", reward.getType());
-                      data.putInt("amount", reward.getAmount());
-                      sendRewardedEvent(
-                          GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD, requestId, adUnitId, null, data);
-                    }
-
-                    @Override
-                    public void onRewardedAdFailedToShow(int errorCode) {
-                      WritableMap error = Arguments.createMap();
-                      String[] codeAndMessage = getCodeAndMessageFromAdErrorCode(errorCode);
-                      error.putString("code", codeAndMessage[0]);
-                      error.putString("message", codeAndMessage[1]);
-                      sendRewardedEvent(GOOGLE_ADS_EVENT_ERROR, requestId, adUnitId, error, null);
-                    }
-                  };
-
-              rewardedAd.show(getCurrentActivity(), adCallback, immersiveModeEnabled);
+              rewardedAd.show(getCurrentActivity(), onUserEarnedRewardListener);
               promise.resolve(null);
             });
   }

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsRewardedModule.java
@@ -5,6 +5,8 @@ import static io.invertase.googleads.ReactNativeGoogleAdsCommon.sendAdEvent;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_ERROR;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD;
 import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_REWARDED_LOADED;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_CLOSED;
+import static io.invertase.googleads.ReactNativeGoogleAdsEvent.GOOGLE_ADS_EVENT_OPENED;
 
 import android.app.Activity;
 import android.util.SparseArray;
@@ -17,6 +19,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
 import com.google.android.gms.ads.rewarded.RewardItem;
 import com.google.android.gms.ads.rewarded.RewardedAd;
@@ -100,6 +103,20 @@ public class ReactNativeGoogleAdsRewardedModule extends ReactNativeModule {
                   rewardedAd.setServerSideVerificationOptions(options.build());
                 }
               }
+
+              FullScreenContentCallback fullScreenContentCallback = new FullScreenContentCallback() {
+                @Override
+                public void onAdShowedFullScreenContent() {
+                  sendRewardedEvent(GOOGLE_ADS_EVENT_OPENED, requestId, adUnitId, null, null);
+                }
+
+                @Override
+                public void onAdDismissedFullScreenContent() {
+                  sendRewardedEvent(GOOGLE_ADS_EVENT_CLOSED, requestId, adUnitId, null, null);
+                }
+              };
+
+              rewardedAd.setFullScreenContentCallback(fullScreenContentCallback);
 
               rewardedAdArray.put(requestId, rewardedAd);
               sendRewardedEvent(

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         kotlinVersion = "1.5.30"
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
+        compileSdkVersion = 31
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
     }

--- a/ios/RNGoogleAds/RNGoogleAdsCommon.h
+++ b/ios/RNGoogleAds/RNGoogleAdsCommon.h
@@ -53,7 +53,6 @@ extern NSString *const GOOGLE_ADS_EVENT_LOADED;
 extern NSString *const GOOGLE_ADS_EVENT_ERROR;
 extern NSString *const GOOGLE_ADS_EVENT_OPENED;
 extern NSString *const GOOGLE_ADS_EVENT_CLICKED;
-extern NSString *const GOOGLE_ADS_EVENT_LEFT_APPLICATION;
 extern NSString *const GOOGLE_ADS_EVENT_CLOSED;
 
 extern NSString *const GOOGLE_ADS_EVENT_REWARDED_LOADED;

--- a/ios/RNGoogleAds/RNGoogleAdsCommon.m
+++ b/ios/RNGoogleAds/RNGoogleAdsCommon.m
@@ -25,7 +25,6 @@ NSString *const GOOGLE_ADS_EVENT_LOADED = @"loaded";
 NSString *const GOOGLE_ADS_EVENT_ERROR = @"error";
 NSString *const GOOGLE_ADS_EVENT_OPENED = @"opened";
 NSString *const GOOGLE_ADS_EVENT_CLICKED = @"clicked";
-NSString *const GOOGLE_ADS_EVENT_LEFT_APPLICATION = @"left_application";
 NSString *const GOOGLE_ADS_EVENT_CLOSED = @"closed";
 NSString *const GOOGLE_ADS_EVENT_REWARDED_LOADED = @"rewarded_loaded";
 NSString *const GOOGLE_ADS_EVENT_REWARDED_EARNED_REWARD = @"rewarded_earned_reward";

--- a/lib/AdEventType.js
+++ b/lib/AdEventType.js
@@ -20,6 +20,5 @@ export default {
   ERROR: 'error',
   OPENED: 'opened',
   CLICKED: 'clicked',
-  LEFT_APPLICATION: 'left_application',
   CLOSED: 'closed',
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -120,7 +120,7 @@ export namespace GoogleAdsTypes {
     /**
      * The user clicked the advert.
      */
-    CLICKED: 'clicked';    
+    CLICKED: 'clicked';
 
     /**
      * The user closed the ad and has returned back to your application.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -216,11 +216,6 @@ export namespace GoogleAdsTypes {
     MEDIUM_RECTANGLE: 'MEDIUM_RECTANGLE';
 
     /**
-     * A dynamically sized banner that is full-width and auto-height.
-     */
-    SMART_BANNER: 'SMART_BANNER';
-
-    /**
      * A (next generation) dynamically sized banner that is full-width and auto-height.
      */
     ADAPTIVE_BANNER: 'ADAPTIVE_BANNER';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -821,7 +821,6 @@ export namespace GoogleAdsTypes {
       | AdEventType['ERROR']
       | AdEventType['OPENED']
       | AdEventType['CLICKED']
-      | AdEventType['LEFT_APPLICATION']
       | AdEventType['CLOSED']
       | RewardedAdEventType['LOADED']
       | RewardedAdEventType['EARNED_REWARD'],

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -120,14 +120,7 @@ export namespace GoogleAdsTypes {
     /**
      * The user clicked the advert.
      */
-    CLICKED: 'clicked';
-
-    /**
-     * The user has left your application (e.g. following the ad).
-     *
-     * Be sure to pause any tasks on this event (such as music or memory intensive tasks).
-     */
-    LEFT_APPLICATION: 'left_application';
+    CLICKED: 'clicked';    
 
     /**
      * The user closed the ad and has returned back to your application.

--- a/type-test.ts
+++ b/type-test.ts
@@ -125,4 +125,3 @@ console.log(googleAds.BannerAdSize.FULL_BANNER);
 console.log(googleAds.BannerAdSize.LARGE_BANNER);
 console.log(googleAds.BannerAdSize.LEADERBOARD);
 console.log(googleAds.BannerAdSize.MEDIUM_RECTANGLE);
-console.log(googleAds.BannerAdSize.SMART_BANNER);

--- a/type-test.ts
+++ b/type-test.ts
@@ -27,13 +27,11 @@ console.log(googleAds.MaxAdContentRating.T);
 console.log(googleAds.AdEventType.CLICKED);
 console.log(googleAds.AdEventType.CLOSED);
 console.log(googleAds.AdEventType.ERROR);
-console.log(googleAds.AdEventType.LEFT_APPLICATION);
 console.log(googleAds.AdEventType.LOADED);
 console.log(googleAds.AdEventType.OPENED);
 console.log(googleAds.AdEventType.CLICKED);
 console.log(googleAds.AdEventType.CLOSED);
 console.log(googleAds.AdEventType.ERROR);
-console.log(googleAds.AdEventType.LEFT_APPLICATION);
 console.log(googleAds.AdEventType.LOADED);
 console.log(googleAds.AdEventType.OPENED);
 


### PR DESCRIPTION
### Description

Android Update Banner, Interstitial, Rewarded add to be compatible with com.google.android.gms:play-services-ads:20.5.0

BREAKING CHANGES:
Please refer to upstream guides for suggestions on new usage. https://developers.google.com/admob/ios/migration and https://developers.google.com/admob/android/migration
- compileSdkVersion now 31, change your app android build.gradle to 31 if you have not already. Note that JDK11 is required for stable compilation on compileSdkVersion 31, JDK8 has internal compiler errors with SDK31
- onAdLeftApplication removed from the underlying SDK, use react-native built in AppState to determine app went to background
- Smart banner ads removed; use adaptive banner ads. Set height/width explicitly taking into account device size