### PR TITLE
docs: improve outbound requests info

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -70,13 +70,12 @@ npx react-native run-android
 
 ## Configure outbound requests
 
-Before requesting ads, you must tell the AdMob network what type of content you'd wish to receive based on your target
-audience.
+If needed, you can provide settings that will apply to all ad requests.
 
 For example, if the application targets children then you must configure the outbound requests to only
 receive content suitable for children before loading any adverts.
 
-To set the request configuration, call the `setRequestConfiguration` method:
+To set the request configuration, call the `setRequestConfiguration` method before requesting ads:
 
 ```js
 import admob, { MaxAdContentRating } from '@invertase/react-native-google-ads';

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -75,7 +75,7 @@ If needed, you can provide settings that will apply to all ad requests.
 For example, if the application targets children then you must configure the outbound requests to only
 receive content suitable for children before loading any adverts.
 
-To set the request configuration, call the `setRequestConfiguration` method before requesting ads:
+If you need to set a custom request configuration, you must call the `setRequestConfiguration` method before requesting ads:
 
 ```js
 import admob, { MaxAdContentRating } from '@invertase/react-native-google-ads';

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -70,7 +70,7 @@ npx react-native run-android
 
 ## Configure outbound requests
 
-If needed, you can provide settings that will apply to all ad requests.
+If the default ad settings are not correct for your app, you can provide settings that will apply to all ad requests.
 
 For example, if the application targets children then you must configure the outbound requests to only
 receive content suitable for children before loading any adverts.


### PR DESCRIPTION
### Description

Currently the docs make it seem like setting setRequestConfiguration is mandatory.
Actually it's only needed if your app requires specific targeting or you need to provide testID's.
