### PR TITLE
feat: expose native SDK initialize methods as new `initialize` API

### DIFF
--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
@@ -17,17 +17,24 @@ package io.invertase.googleads;
  *
  */
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.initialization.AdapterStatus;
+import com.google.android.gms.ads.initialization.InitializationStatus;
+import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 import com.google.android.gms.ads.RequestConfiguration;
 import io.invertase.googleads.common.ReactNativeModule;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 public class ReactNativeGoogleAdsModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleAdsModule";
@@ -105,6 +112,24 @@ public class ReactNativeGoogleAdsModule extends ReactNativeModule {
     }
 
     return builder.build();
+  }
+
+  @ReactMethod
+  public void initialize(Promise promise) {
+    MobileAds.initialize(getContext(), new OnInitializationCompleteListener() {
+      @Override
+      public void onInitializationComplete(InitializationStatus initializationStatus) {
+        WritableArray result = Arguments.createArray();
+        for (Map.Entry<String, AdapterStatus> entry: initializationStatus.getAdapterStatusMap().entrySet()) {
+          WritableMap info = Arguments.createMap();
+          info.putString("name", entry.getKey());
+          info.putInt("state", entry.getValue().getInitializationState().ordinal());
+          info.putString("description", entry.getValue().getDescription());
+          result.pushMap(info);
+        }
+        promise.resolve(result);
+      }
+    });
   }
 
   @ReactMethod

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsModule.java
@@ -26,15 +26,15 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.gms.ads.initialization.AdapterStatus;
 import com.google.android.gms.ads.initialization.InitializationStatus;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
-import com.google.android.gms.ads.RequestConfiguration;
 import io.invertase.googleads.common.ReactNativeModule;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Map;
+import java.util.Objects;
 
 public class ReactNativeGoogleAdsModule extends ReactNativeModule {
   private static final String SERVICE = "RNGoogleAdsModule";
@@ -116,20 +116,23 @@ public class ReactNativeGoogleAdsModule extends ReactNativeModule {
 
   @ReactMethod
   public void initialize(Promise promise) {
-    MobileAds.initialize(getContext(), new OnInitializationCompleteListener() {
-      @Override
-      public void onInitializationComplete(InitializationStatus initializationStatus) {
-        WritableArray result = Arguments.createArray();
-        for (Map.Entry<String, AdapterStatus> entry: initializationStatus.getAdapterStatusMap().entrySet()) {
-          WritableMap info = Arguments.createMap();
-          info.putString("name", entry.getKey());
-          info.putInt("state", entry.getValue().getInitializationState().ordinal());
-          info.putString("description", entry.getValue().getDescription());
-          result.pushMap(info);
-        }
-        promise.resolve(result);
-      }
-    });
+    MobileAds.initialize(
+        getContext(),
+        new OnInitializationCompleteListener() {
+          @Override
+          public void onInitializationComplete(InitializationStatus initializationStatus) {
+            WritableArray result = Arguments.createArray();
+            for (Map.Entry<String, AdapterStatus> entry :
+                initializationStatus.getAdapterStatusMap().entrySet()) {
+              WritableMap info = Arguments.createMap();
+              info.putString("name", entry.getKey());
+              info.putInt("state", entry.getValue().getInitializationState().ordinal());
+              info.putString("description", entry.getValue().getDescription());
+              result.pushMap(info);
+            }
+            promise.resolve(result);
+          }
+        });
   }
 
   @ReactMethod

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -75,7 +75,7 @@ If the default ad settings are not correct for your app, you can provide setting
 For example, if the application targets children then you must configure the outbound requests to only
 receive content suitable for children before loading any adverts.
 
-If you need to set a custom request configuration, you must call the `setRequestConfiguration` method before requesting ads:
+If you need to set a custom request configuration, you must call the `setRequestConfiguration` method before initializing the Google Mobile Ads SDK:
 
 ```js
 import admob, { MaxAdContentRating } from '@invertase/react-native-google-ads';
@@ -101,6 +101,26 @@ admob()
 ```
 
 To learn more about the request configuration settings, view the [`RequestConfiguration`](/reference/admob/requestconfiguration) documentation.
+
+## Initialize the Google Mobile Ads SDK
+
+Before loading ads, have your app initialize the Google Mobile Ads SDK by calling `initialize` which initializes the SDK and returns a promise once initialization is complete (or after a 30-second timeout).
+This needs to be done only once, ideally at app launch.
+
+> ⚠️ **Warning:** Ads may be preloaded by the Mobile Ads SDK or mediation partner SDKs upon calling `initialize`.
+If you need to obtain consent from users in the European Economic Area (EEA), set any request-specific flags (such as tagForChildDirectedTreatment), or otherwise take action before loading ads, ensure you do so before initializing the Mobile Ads SDK.
+
+```js
+import admob from '@invertase/react-native-google-ads';
+
+admob()
+  .initialize()
+  .then((adapterStatuses) => {
+    // Initialization complete!
+  });
+```
+
+If you are using mediation, you may wish to wait until the Mobile Ads SDK is initialized before loading ads, as this will ensure that all mediation adapters are initialized.
 
 ## European User Consent
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -120,7 +120,7 @@ admob()
   });
 ```
 
-If you are using mediation, you may wish to wait until the Mobile Ads SDK is initialized before loading ads, as this will ensure that all mediation adapters are initialized.
+If you are using mediation, you may wish to wait until the promise is settled before loading ads, as this will ensure that all mediation adapters are initialized.
 
 ## European User Consent
 

--- a/ios/RNGoogleAds/RNGoogleAdsModule.m
+++ b/ios/RNGoogleAds/RNGoogleAdsModule.m
@@ -34,23 +34,22 @@ RCT_EXPORT_MODULE();
 #pragma mark -
 #pragma mark Google Mobile Ads Methods
 
-RCT_EXPORT_METHOD(initialize
-                  : (RCTPromiseResolveBlock)resolve
-                  : (RCTPromiseRejectBlock)reject) {
-  [[GADMobileAds sharedInstance] startWithCompletionHandler:^(GADInitializationStatus * _Nonnull status) {
-    NSDictionary *adapterStatuses = [status adapterStatusesByClassName];
-    NSMutableArray *result = [[NSMutableArray alloc] init];
-    for (NSString *adapter in adapterStatuses) {
-      GADAdapterStatus *adapterStatus = adapterStatuses[adapter];
-      NSDictionary *dict = @{
-        @"name": adapter,
-        @"state": @(adapterStatus.state),
-        @"description": adapterStatus.description
-      };
-      [result addObject:dict];
-    }
-    resolve(result);
-  }];
+RCT_EXPORT_METHOD(initialize : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
+  [[GADMobileAds sharedInstance]
+      startWithCompletionHandler:^(GADInitializationStatus *_Nonnull status) {
+        NSDictionary *adapterStatuses = [status adapterStatusesByClassName];
+        NSMutableArray *result = [[NSMutableArray alloc] init];
+        for (NSString *adapter in adapterStatuses) {
+          GADAdapterStatus *adapterStatus = adapterStatuses[adapter];
+          NSDictionary *dict = @{
+            @"name" : adapter,
+            @"state" : @(adapterStatus.state),
+            @"description" : adapterStatus.description
+          };
+          [result addObject:dict];
+        }
+        resolve(result);
+      }];
 }
 
 RCT_EXPORT_METHOD(setRequestConfiguration

--- a/ios/RNGoogleAds/RNGoogleAdsModule.m
+++ b/ios/RNGoogleAds/RNGoogleAdsModule.m
@@ -38,12 +38,17 @@ RCT_EXPORT_METHOD(initialize
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[GADMobileAds sharedInstance] startWithCompletionHandler:^(GADInitializationStatus * _Nonnull status) {
-    NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
-    [status.adapterStatusesByClassName enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL *stop) {
-      NSMutableDictionary *adapterStatus = [[NSMutableDictionary alloc] init];
-      adapterStatus[@"description"] = [object description];
-      result[key] = adapterStatus;
-    }];
+    NSDictionary *adapterStatuses = [status adapterStatusesByClassName];
+    NSMutableArray *result = [[NSMutableArray alloc] init];
+    for (NSString *adapter in adapterStatuses) {
+      GADAdapterStatus *adapterStatus = adapterStatuses[adapter];
+      NSDictionary *dict = @{
+        @"name": adapter,
+        @"state": @(adapterStatus.state),
+        @"description": adapterStatus.description
+      };
+      [result addObject:dict];
+    }
     resolve(result);
   }];
 }

--- a/ios/RNGoogleAds/RNGoogleAdsModule.m
+++ b/ios/RNGoogleAds/RNGoogleAdsModule.m
@@ -34,6 +34,20 @@ RCT_EXPORT_MODULE();
 #pragma mark -
 #pragma mark Google Mobile Ads Methods
 
+RCT_EXPORT_METHOD(initialize
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  [[GADMobileAds sharedInstance] startWithCompletionHandler:^(GADInitializationStatus * _Nonnull status) {
+    NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+    [status.adapterStatusesByClassName enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL *stop) {
+      NSMutableDictionary *adapterStatus = [[NSMutableDictionary alloc] init];
+      adapterStatus[@"description"] = [object description];
+      result[key] = adapterStatus;
+    }];
+    resolve(result);
+  }];
+}
+
 RCT_EXPORT_METHOD(setRequestConfiguration
                   : (NSDictionary *)requestConfiguration
                   : (RCTPromiseResolveBlock)resolve

--- a/lib/googleMobileAds.js
+++ b/lib/googleMobileAds.js
@@ -26,6 +26,10 @@ class GoogleAdsModule extends Module {
     });
   }
 
+  initialize() {
+    return this.native.initialize();
+  }
+
   setRequestConfiguration(requestConfiguration) {
     let config;
     try {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -726,15 +726,13 @@ export namespace GoogleAdsTypes {
   }
 
   /**
-   * Initialization status of each ad network available to the Google Mobile Ads SDK, keyed by its
-   * GADMAdapter's class name. The list of available ad networks may be incomplete during early
-   * phases of SDK initialization.
+   * An immutable snapshot of a mediation adapter's initialization status.
    */
-  export type InitializationStatus = {
+  export type AdapterStatus = {
     name: string;
     description: string;
     status: 0 | 1;
-  }[];
+  };
 
   /**
    * The `RequestConfiguration` used when setting global ad settings via `setRequestConfiguration`.
@@ -1137,7 +1135,7 @@ export namespace GoogleAdsTypes {
     /**
      * Initialize the SDK.
      */
-    initialize(): Promise<InitializationStatus>;
+    initialize(): Promise<AdapterStatus[]>;
 
     /**
      * Sets request options for all future ad requests.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -730,11 +730,11 @@ export namespace GoogleAdsTypes {
    * GADMAdapter's class name. The list of available ad networks may be incomplete during early
    * phases of SDK initialization.
    */
-  export interface InitializationStatus {
-    [adapterClassName: string]: {
-      description: string;
-    };
-  }
+  export type InitializationStatus = {
+    name: string;
+    description: string;
+    status: 0 | 1;
+  }[];
 
   /**
    * The `RequestConfiguration` used when setting global ad settings via `setRequestConfiguration`.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -726,6 +726,17 @@ export namespace GoogleAdsTypes {
   }
 
   /**
+   * Initialization status of each ad network available to the Google Mobile Ads SDK, keyed by its
+   * GADMAdapter's class name. The list of available ad networks may be incomplete during early
+   * phases of SDK initialization.
+   */
+  export interface InitializationStatus {
+    [adapterClassName: string]: {
+      description: string;
+    };
+  }
+
+  /**
    * The `RequestConfiguration` used when setting global ad settings via `setRequestConfiguration`.
    */
   export interface RequestConfiguration {
@@ -1123,6 +1134,11 @@ export namespace GoogleAdsTypes {
    * The Google Ads service interface.
    */
   export class Module {
+    /**
+     * Initialize the SDK.
+     */
+    initialize(): Promise<InitializationStatus>;
+
     /**
      * Sets request options for all future ad requests.
      *


### PR DESCRIPTION
### Description

It has been adviced to initialize the sdk before loading ads. (Especially when using mediation).
Therefore these methods should be exposed to RN.

Solves: #4
