### PR TITLE
fix: no banner ads loaded on Android in the first render

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@
 
 ---
 
-Think `react-native-admob` is great? Please consider supporting the project with any of the below:
+Think `react-native-google-ads` is great? Please consider supporting the project with any of the below:
 
 - 👉 Star this repo on GitHub ⭐️
 - 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter

--- a/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
+++ b/android/src/main/java/io/invertase/googleads/ReactNativeGoogleAdsBannerAdViewManager.java
@@ -87,11 +87,13 @@ public class ReactNativeGoogleAdsBannerAdViewManager extends SimpleViewManager<R
   @ReactProp(name = "unitId")
   public void setUnitId(ReactViewGroup reactViewGroup, String value) {
     unitId = value;
+    requestAd(reactViewGroup);
   }
 
   @ReactProp(name = "request")
   public void setRequest(ReactViewGroup reactViewGroup, ReadableMap value) {
     request = ReactNativeGoogleAdsCommon.buildAdRequest(value);
+    requestAd(reactViewGroup);
   }
 
   @ReactProp(name = "size")


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Fixes initial loads of `<BannerAd>`. See #58 for details.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

Fixes #58 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-google-ads/blob/main/CONTRIBUTING.md)
  and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `__tests__e2e__`
  - [ ] `jest` tests added or updated in `__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-admob` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`Invertase`](https://twitter.com/invertaseio) on Twitter
